### PR TITLE
Generic KINTEX7 define for KC705 and Genesys 2

### DIFF
--- a/dualmem_widen.sv
+++ b/dualmem_widen.sv
@@ -21,7 +21,7 @@ module dualmem_widen(clka, clkb, dina, dinb, addra, addrb, wea, web, douta, dout
 `endif
 */
    
-`ifdef GENESYSII
+`ifdef KINTEX7
  `define RAMB16
 `endif
 

--- a/dualmem_widen8.sv
+++ b/dualmem_widen8.sv
@@ -28,7 +28,7 @@ module dualmem_widen8(clka, clkb, dina, dinb, addra, addrb, wea, web, douta, dou
 `endif
 */
    
-`ifdef GENESYSII
+`ifdef KINTEX7
  `define RAMB16
 `endif
 


### PR DESCRIPTION
Changed the define used in the dualmem to enable support for the [Xilinx Kintex-7 FPGA KC705 Evaluation Kit](https://www.xilinx.com/products/boards-and-kits/ek-k7-kc705-g.html) and possibly other boards from the Kintex-7 series.

This PR is necessary for PR pulp-platform/ariane#262.